### PR TITLE
[WIP] Receives tarred rust binary and runs proper command to execute

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -24,7 +24,7 @@ module.exports.js = {
 };
 
 module.exports.rs = {
-  execute: () => [rust.exports.meta.binary],
+  execute: () => [rust.meta.binary],
 };
 
 module.exports.py = {

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -23,7 +23,9 @@ var exportables = {
   meta: {
     name: 'rust',
     extname: 'rs',
-    binary: 'rust_executable',
+    // TODO: do not hardcode the binary name
+    binary: '/tmp/remote-script/hello',
+    // TODO: do not hardcode the entry
     entry: 'src/main.rs',
     configuration: 'Cargo.toml',
     checkConfiguration: (pushdir, basename, program) => {
@@ -98,19 +100,12 @@ exportables.remoteRustCompilation = function(opts) {
       }
     };
 
-    // Create a new tar pack for incoming executable data
-    var pack = tarStream.pack();
-    // Create the entry file name
-    var entry = pack.entry({
-      name: exportables.meta.binary
-    });
-
     // Set up the request
     var post_req = http.request(post_options, function(res) {
       // When we get incoming binary data, save to our buffers
       res.on('data', function(chunk) {
           // Write this incoming data to our tar packer
-          entry.write(chunk);
+          buffers.push(chunk);
         })
         // Reject on failure
         .on('error', function(e) {
@@ -118,22 +113,8 @@ exportables.remoteRustCompilation = function(opts) {
         })
         // When the post completes, resolve with the executable
         .on('end', function() {
-          // Indicate that all data has been received
-          pack.finalize();
-
-          // Turn the stream into an array of buffers
-          return streamToArray(pack)
-            .then((arr) => {
-              // For each buffer in the array
-              for (var i = 0, l = arr.length; i < l; ++i) {
-                // Grab the part
-                var part = parts[i];
-                // Push it into our buffer array
-                buffers.push((part instanceof Buffer) ? part : new Buffer(part));
-              }
-              // Resolve with concatenated buffers
-              return resolve(Buffer.concat(buffers));
-            });
+          // Resolve with concatenated buffers
+          return resolve(Buffer.concat(buffers));
         });
     });
 


### PR DESCRIPTION
Dependent on https://github.com/tessel/rust-compilation-server/pull/5.

The cross compilation server will now archive the resulting Rust binary folder before passing the response back to the CLI. This PR removes code that was supposed to archive the incoming binary on the CLI as it is no longer necessary.

Additionally, this PR fixes a bug when attempting to execute the Rust code (`rust.exports.meta` was nto defined).

There are still a bunch of things to fix (marked with `TODO` in the CLI and on the cross compilation server).